### PR TITLE
Include logLevel in Handler.emitRecord

### DIFF
--- a/Sources/Evergreen/Formatter.swift
+++ b/Sources/Evergreen/Formatter.swift
@@ -69,7 +69,7 @@ public class Formatter {
     
     /// Produces a record from a given event. The record can be subsequently emitted by a handler.
     public final func recordFromEvent<M>(event: Event<M>) -> Record {
-        return Record(date: event.date, description: self.stringFromEvent(event))
+        return Record(date: event.date, logLevel: event.logLevel, description: self.stringFromEvent(event))
     }
     
     public func stringFromEvent<M>(event: Event<M>) -> String

--- a/Sources/Evergreen/Handler.swift
+++ b/Sources/Evergreen/Handler.swift
@@ -14,6 +14,7 @@ import Foundation
 public struct Record: CustomStringConvertible {
 
     public let date: NSDate
+    public let logLevel: LogLevel?
     public let description: String
     
 }


### PR DESCRIPTION
Some log destinations like ASL can make use of the log level
