### PR TITLE
Should use top level defaultLogger, not static member

### DIFF
--- a/Sources/Evergreen/Logger.swift
+++ b/Sources/Evergreen/Logger.swift
@@ -489,8 +489,8 @@ extension Logger: CustomStringConvertible {
     }
 
     public func description(_ keyPathSeparator: String? = nil) -> String {
-        var keyPath = self.keyPath(upToParent: defaultLogger)
-        if self.root !== defaultLogger {
+        var keyPath = self.keyPath(upToParent: Evergreen.defaultLogger)
+        if self.root !== Evergreen.defaultLogger {
             keyPath = keyPath.keyPathByPrependingComponent("DETACHED")
         }
         return keyPath.description(separator: keyPathSeparator)


### PR DESCRIPTION
Swift development snapshot 09-12 cannot compile Evergreen, as it is confused about which `defaultLogger` it should use.