### PR TITLE
Fix FileHandler file path resolution

### DIFF
--- a/Sources/Evergreen/Handler.swift
+++ b/Sources/Evergreen/Handler.swift
@@ -85,7 +85,7 @@ public class FileHandler: Handler, CustomStringConvertible {
         guard fileURL.isFileURL else {
             return nil
         }
-        let path = fileURL.absoluteString
+        let path = fileURL.path
         guard fileManager.createFile(atPath: path, contents: nil, attributes: nil) else {
             return nil
         }


### PR DESCRIPTION
The latest commits break the FileHandler file path resolution.

Currently, FileHandler initializer always returns nil because file path is created using `fileURL.absoluteString` instead of `fileURL.path`.

In fact, for a local file "mylog.txt" located in /tmp, path will be "file://tmp/mylog.txt" if `absoluteString` is used. Thus `FileManager.createFile()` will fail with this path, because the function expects a regular path like "/tmp/mylog.txt"